### PR TITLE
Support positioning against rectangles

### DIFF
--- a/src/core/button.js
+++ b/src/core/button.js
@@ -21,7 +21,7 @@ PROTOTYPE._createButton = function()
 		})
 		.prepend(
 			$('<span />', {
-				'class': 'ui-icon ui-icon-close',
+				'class': 'ui-icon ui-icon icon-close',
 				'html': '&times;'
 			})
 		);

--- a/src/core/defaults.js
+++ b/src/core/defaults.js
@@ -28,6 +28,12 @@ QTIP.defaults = {
 		target: FALSE,
 		container: FALSE,
 		viewport: FALSE,
+		viewportDeflate: {
+			top: 0,
+			left: 0,
+			bottom: 0,
+			right: 0
+		},
 		adjust: {
 			x: 0, y: 0,
 			mouse: TRUE,

--- a/src/core/position.js
+++ b/src/core/position.js
@@ -38,6 +38,16 @@ PROTOTYPE.reposition = function(event, effect) {
 		position = { left: target[0], top: target[1] };
 	}
 
+	// Check if an absolute rectangle was passed
+	else if($.isPlainObject(target)) {
+		targetWidth = target.right - target.left;
+		targetHeight = target.bottom - target.top;
+
+		position = { left: target.left, top: target.top };
+		position.left += at.x === RIGHT ? targetWidth : at.x === CENTER ? targetWidth / 2 : 0;
+		position.top += at.y === BOTTOM ? targetHeight : at.y === CENTER ? targetHeight / 2 : 0;
+	}
+
 	// Check if mouse was the target
 	else if(target === 'mouse') {
 		// Force left top to allow flipping
@@ -270,7 +280,7 @@ C.string = function(join) {
 	var x = this.x, y = this.y;
 
 	var result = x !== y ?
-		(x === 'center' || y !== 'center' && (this.precedance === Y || this.forceY) ? 
+		(x === 'center' || y !== 'center' && (this.precedance === Y || this.forceY) ?
 			[y,x] : [x,y]
 		) :
 	[x];

--- a/src/position/viewport.js
+++ b/src/position/viewport.js
@@ -13,7 +13,7 @@ PLUGINS.viewport = function(api, position, posOptions, targetWidth, targetHeight
 		cache = api.cache,
 		adjusted = { left: 0, top: 0 },
 		fixed, newMy, containerOffset, containerStatic,
-		viewportWidth, viewportHeight, viewportScroll, viewportOffset;
+		viewportWidth, viewportHeight, viewportScroll, viewportOffset, viewportDeflate;
 
 	// If viewport is not a jQuery element, or it's the window/document, or no adjustment method is used... return
 	if(!viewport.jquery || target[0] === window || target[0] === document.body || adjust.method === 'none') {
@@ -30,6 +30,13 @@ PLUGINS.viewport = function(api, position, posOptions, targetWidth, targetHeight
 	viewportHeight = viewport[0] === window ? viewport.height() : viewport.outerHeight(FALSE);
 	viewportScroll = { left: fixed ? 0 : viewport.scrollLeft(), top: fixed ? 0 : viewport.scrollTop() };
 	viewportOffset = viewport.offset() || adjusted;
+
+	// Deflate (or inflate) the viewport edges
+	viewportDeflate = posOptions.viewportDeflate;
+	viewportOffset.top += viewportDeflate.top;
+	viewportOffset.left += viewportDeflate.left;
+	viewportHeight -= (viewportDeflate.top + viewportDeflate.bottom);
+	viewportWidth -= (viewportDeflate.left + viewportDeflate.right);
 
 	// Generic calculation method
 	function calculate(side, otherSide, type, adjust, side1, side2, lengthName, targetLength, elemLength) {

--- a/src/tips/tips.js
+++ b/src/tips/tips.js
@@ -469,11 +469,6 @@ $.extend(Tip.prototype, {
 		// Adjust for tip size
 		position[ corner[precedance] ] -= size[ precedance === X ? 0 : 1 ];
 
-		// Zoom fix: Force the tip to be 1px overlapping with the rest of the tooltip
-		// This prevents any visible gaps when the page is zoomed.
-		overlap = position[ corner[precedance] ] > 0 ? -1 : 1;
-		position[ corner[precedance] ] += overlap;
-
 		// Set and return new position
 		tip.css({ margin: '', top: '', bottom: '', left: '', right: '' }).css(position);
 		return position;


### PR DESCRIPTION
This change does a few things:
1. It supports positioning a tooltip against a rectangle by adding another format that `position.target` looks for
2. It supports deflating the viewport container so that it is not tightly coupled to the viewport's actual size. Deflating can be used to ensure tooltips maintain a certain distance from the edge of the viewport
3. It backports our various frontend changes
